### PR TITLE
Add checks for trade order and watch error events

### DIFF
--- a/src/contract_wrappers/MarketContractWrapper.ts
+++ b/src/contract_wrappers/MarketContractWrapper.ts
@@ -21,8 +21,8 @@ export class MarketContractWrapper {
   // *****************************************************************
   // ****                     Members                             ****
   // *****************************************************************
-  readonly ORDER_EXPIRED_CODE = '0';
-  readonly ORDER_DEAD_CODE = '1';
+  static readonly ORDER_EXPIRED_CODE = '0';
+  static readonly ORDER_DEAD_CODE = '1';
 
   protected readonly _web3: Web3;
   private readonly _marketContractsByAddress: { [address: string]: MarketContract };
@@ -315,9 +315,9 @@ export class MarketContractWrapper {
               .then(stopEventWatcher)
               .then(() => {
                 switch (eventLog.args.errorCode.toString()) {
-                  case this.ORDER_EXPIRED_CODE:
+                  case MarketContractWrapper.ORDER_EXPIRED_CODE:
                     return reject(new Error(MarketError.OrderExpired));
-                  case this.ORDER_DEAD_CODE:
+                  case MarketContractWrapper.ORDER_DEAD_CODE:
                     return reject(new Error(MarketError.OrderDead));
                   default:
                     return reject(new Error(MarketError.UnknownOrderError));

--- a/src/types/MarketError.ts
+++ b/src/types/MarketError.ts
@@ -14,5 +14,6 @@ export enum MarketError {
   InvalidTaker = 'INVALID_TAKER',
   OrderExpired = 'ORDER_EXPIRED',
   OrderFilledOrCancelled = 'ORDER_FILLED_OR_CANCELLED',
-  BuySellMismatch = 'BUY/SELL MISMATCH'
+  BuySellMismatch = 'BUY/SELL MISMATCH',
+  ContractAlreadySettled = 'CONTRACT_ALREADY_SETTLED'
 }

--- a/src/types/MarketError.ts
+++ b/src/types/MarketError.ts
@@ -13,6 +13,8 @@ export enum MarketError {
   SubscriptionAlreadyPresent = 'SUBSCRIPTION_ALREADY_PRESENT',
   InvalidTaker = 'INVALID_TAKER',
   OrderExpired = 'ORDER_EXPIRED',
+  OrderDead = 'ORDER_DEAD',
+  UnknownOrderError = 'UNKNOWN_ORDER_ERROR',
   OrderFilledOrCancelled = 'ORDER_FILLED_OR_CANCELLED',
   BuySellMismatch = 'BUY/SELL MISMATCH',
   ContractAlreadySettled = 'CONTRACT_ALREADY_SETTLED'

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,6 +1,9 @@
 import { join } from 'path';
 import { readFileSync } from 'fs';
 
+import Web3 from 'web3';
+import { JSONRPCResponsePayload } from '@0xproject/types';
+
 /**
  * Pulls a contract address fom a truffle artifact .json file.  Assumes these files
  * are located in MARKET.js/build/contracts.  Currently no error handling is present.
@@ -26,4 +29,57 @@ export function isUrl(url: string): boolean {
   return /^(?:(?:(?:https?|ftp):)?\/\/)(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})))(?::\d{2,5})?(?:[/?#]\S*)?$/i.test(
     url
   );
+}
+
+/**
+ * Creates an EVM Snapshot and returns a Promise that resolves to the id of the snapshot.
+ *
+ * @param {Web3} web3 Web3 object
+ */
+export async function createEVMSnapshot(web3: Web3): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    web3.currentProvider.sendAsync(
+      {
+        jsonrpc: '2.0',
+        method: 'evm_snapshot',
+        params: [],
+        id: new Date().getTime()
+      },
+      (err: Error | null, response?: JSONRPCResponsePayload) => {
+        if (err) {
+          reject(err);
+        }
+        if (response) {
+          resolve(response.result);
+        }
+      }
+    );
+  });
+}
+
+/**
+ * Restores the EVM to the snapshot set in id
+ *
+ * @param {Web3} web3
+ * @param {string} snapshotId
+ */
+export async function restoreEVMSnapshot(web3: Web3, snapshotId: string): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    web3.currentProvider.sendAsync(
+      {
+        jsonrpc: '2.0',
+        method: 'evm_revert',
+        params: [snapshotId],
+        id: new Date().getTime()
+      },
+      (err: Error | null, response?: JSONRPCResponsePayload) => {
+        if (err) {
+          reject(err);
+        }
+        if (response) {
+          resolve();
+        }
+      }
+    );
+  });
 }


### PR DESCRIPTION
##### Description

- [x] Add check for approval amounts of MKT We currently are checking that if there are fees, the maker and taker both have enough MKT in order to pay for those fees, but we do not check that they have approved sufficient qty (by calling ERC20.approve()) to be able to transfer those fees to the feeRecipient
- [x] Add check to ensure the MarketContract.isSettled is false
- [x] Add watch for the ErrorEvent from MarketContract and return any errors found during the call to traderOrderAsync (see the OrderFilledEvent watch for needed filters and reference)
- [x] Create needed tests for all of these scenarios. (note, the ErrorEvent may be a bit challenging for an automated test to reproduce)

##### Checklist
- [x] Linter status: 100% pass
- [x] Changes don't break existing behavior
- [ ] Tests coverage hasn't decreased

##### Testing
Updates tests

##### Refers/Fixes
Fixes: #78 
