### PR TITLE
cleans up all fx calls with orderLib to avoid redundancy and simplify our API

### DIFF
--- a/src/Market.ts
+++ b/src/Market.ts
@@ -356,15 +356,11 @@ export class Market {
 
   /**
    * Computes the orderHash for a supplied order.
-   * @param {string} orderLibAddress       Address of the deployed OrderLib.
    * @param {Order | SignedOrder} order    An object that conforms to the Order or SignedOrder interface definitions.
    * @return {Promise<string>}             The resulting orderHash from hashing the supplied order.
    */
-  public async createOrderHashAsync(
-    orderLibAddress: string,
-    order: Order | SignedOrder
-  ): Promise<string> {
-    return createOrderHashAsync(this._web3.currentProvider, orderLibAddress, order);
+  public async createOrderHashAsync(order: Order | SignedOrder): Promise<string> {
+    return createOrderHashAsync(this._web3.currentProvider, this.orderLib, order);
   }
 
   /**
@@ -377,12 +373,7 @@ export class Market {
     signedOrder: SignedOrder,
     orderHash: string
   ): Promise<boolean> {
-    return isValidSignatureAsync(
-      this._web3.currentProvider,
-      this.orderLib.address,
-      signedOrder,
-      orderHash
-    );
+    return isValidSignatureAsync(this._web3.currentProvider, this.orderLib, signedOrder, orderHash);
   }
 
   /**
@@ -399,7 +390,6 @@ export class Market {
 
   /***
    * Creates and signs a new order given the arguments provided
-   * @param {string} orderLibAddress          address of the deployed OrderLib.sol
    * @param {string} contractAddress          address of the deployed MarketContract.sol
    * @param {BigNumber} expirationTimestamp   unix timestamp
    * @param {string} feeRecipient             address of account to receive fees
@@ -413,7 +403,6 @@ export class Market {
    * @return {Promise<SignedOrder>}
    */
   public async createSignedOrderAsync(
-    orderLibAddress: string,
     contractAddress: string,
     expirationTimestamp: BigNumber,
     feeRecipient: string,
@@ -427,7 +416,7 @@ export class Market {
   ): Promise<SignedOrder> {
     return createSignedOrderAsync(
       this._web3.currentProvider,
-      orderLibAddress,
+      this.orderLib,
       contractAddress,
       expirationTimestamp,
       feeRecipient,
@@ -457,7 +446,7 @@ export class Market {
     txParams: ITxParams = {}
   ): Promise<OrderTransactionInfo> {
     return this.marketContractWrapper.tradeOrderAsync(
-      this.orderLib.address,
+      this.orderLib,
       signedOrder,
       fillQty,
       txParams

--- a/src/Market.ts
+++ b/src/Market.ts
@@ -360,7 +360,7 @@ export class Market {
    * @return {Promise<string>}             The resulting orderHash from hashing the supplied order.
    */
   public async createOrderHashAsync(order: Order | SignedOrder): Promise<string> {
-    return createOrderHashAsync(this._web3.currentProvider, this.orderLib, order);
+    return createOrderHashAsync(this.orderLib, order);
   }
 
   /**
@@ -373,7 +373,7 @@ export class Market {
     signedOrder: SignedOrder,
     orderHash: string
   ): Promise<boolean> {
-    return isValidSignatureAsync(this._web3.currentProvider, this.orderLib, signedOrder, orderHash);
+    return isValidSignatureAsync(this.orderLib, signedOrder, orderHash);
   }
 
   /**

--- a/src/contract_wrappers/ContractWrapper.ts
+++ b/src/contract_wrappers/ContractWrapper.ts
@@ -9,6 +9,7 @@ import {
   MarketCollateralPool,
   MarketContract,
   Order,
+  OrderLib,
   SignedOrder
 } from '@marketprotocol/types';
 import { MarketError } from '../types';
@@ -98,21 +99,20 @@ export class ContractWrapper {
   }
 
   /**
-   * Trades an order and returns success or error.
-   * @param {string} orderLibAddress          Address of the deployed OrderLib.
-   * @param   signedOrder                     An object that conforms to the SignedOrder interface. The
-   *                                          signedOrder you wish to validate.
-   * @param   fillQty                         The amount of the order that you wish to fill.
-   * @param   txParams                        Transaction params of web3.
-   * @returns {Promise<OrderTransactionInfo>} Information about this order transaction.
+   * Trades an order
+   * @param {OrderLib} orderLib
+   * @param {SignedOrder} signedOrder         An object that conforms to the SignedOrder interface.
+   *                                          The signedOrder you wish to validate.
+   * @param {BigNumber} fillQty               The amount of the order that you wish to fill.
+   * @param {ITxParams} txParams              Transaction params of web3.
+   * @return {Promise<OrderTransactionInfo>}  Information about this order transaction.
    */
   public async tradeOrderAsync(
-    orderLibAddress: string,
+    orderLib: OrderLib,
     signedOrder: SignedOrder,
     fillQty: BigNumber,
     txParams: ITxParams = {}
   ): Promise<OrderTransactionInfo> {
-    assert.isETHAddressHex('orderLibAddress', orderLibAddress);
     // assert.isSchemaValid('SignedOrder', signedOrder, schemas.SignedOrderSchema);
 
     const contractSetWrapper: ContractSet = await this._getContractSetByMarketContractAddressAsync(
@@ -143,15 +143,11 @@ export class ContractWrapper {
       return Promise.reject(new Error(MarketError.BuySellMismatch));
     }
 
-    const orderHash = await createOrderHashAsync(
-      this._web3.currentProvider,
-      orderLibAddress,
-      signedOrder
-    );
+    const orderHash = await createOrderHashAsync(this._web3.currentProvider, orderLib, signedOrder);
 
     const validSignature = await isValidSignatureAsync(
       this._web3.currentProvider,
-      orderLibAddress,
+      orderLib,
       signedOrder,
       orderHash
     );

--- a/src/contract_wrappers/ContractWrapper.ts
+++ b/src/contract_wrappers/ContractWrapper.ts
@@ -143,14 +143,9 @@ export class ContractWrapper {
       return Promise.reject(new Error(MarketError.BuySellMismatch));
     }
 
-    const orderHash = await createOrderHashAsync(this._web3.currentProvider, orderLib, signedOrder);
+    const orderHash = await createOrderHashAsync(orderLib, signedOrder);
 
-    const validSignature = await isValidSignatureAsync(
-      this._web3.currentProvider,
-      orderLib,
-      signedOrder,
-      orderHash
-    );
+    const validSignature = await isValidSignatureAsync(orderLib, signedOrder, orderHash);
 
     if (!validSignature) {
       return Promise.reject(new Error(MarketError.InvalidSignature));

--- a/src/lib/Order.ts
+++ b/src/lib/Order.ts
@@ -10,13 +10,11 @@ import { assert } from '../assert';
 
 /**
  * Computes the orderHash for a supplied order.
- * @param {Provider} provider           Web3 provider instance.
  * @param {OrderLib} orderLib           OrderLib.sol type chain object
  * @param {Order | SignedOrder} order   An object that confirms to the Order interface definitions.
  * @return {Promise<string>}            The resulting orderHash from hashing the supplied order.
  */
 export async function createOrderHashAsync(
-  provider: Provider,
   orderLib: OrderLib,
   order: Order | SignedOrder
 ): Promise<string> {
@@ -86,11 +84,11 @@ export async function createSignedOrderAsync(
     takerFee: takerFee
   };
 
-  const orderHash: string | BigNumber = await createOrderHashAsync(provider, orderLib, order);
+  const orderHash: string = await createOrderHashAsync(orderLib, order);
 
   const signedOrder: SignedOrder = {
     ...order,
-    ecSignature: await signOrderHashAsync(provider, String(orderHash), maker)
+    ecSignature: await signOrderHashAsync(provider, orderHash, maker)
   };
 
   return signedOrder;
@@ -98,14 +96,12 @@ export async function createSignedOrderAsync(
 
 /**
  * Confirms a signed order is validly signed
- * @param {Provider} provider
  * @param {OrderLib} orderLib
  * @param {SignedOrder} signedOrder
  * @param {string} orderHash
  * @return {Promise<boolean>}         if order hash and signature resolve to maker address (signer)
  */
 export async function isValidSignatureAsync(
-  provider: Provider,
   orderLib: OrderLib,
   signedOrder: SignedOrder,
   orderHash: string

--- a/test/ExpirationWatcher.test.ts
+++ b/test/ExpirationWatcher.test.ts
@@ -6,7 +6,6 @@ import DoneCallback = jest.DoneCallback;
 // Types
 import { Market, MARKETProtocolConfig, Utils } from '../src';
 import { constants } from '../src/constants';
-import { getContractAddress } from './utils';
 import { ExpirationWatcher } from '../src/order_watcher/ExpirationWatcher';
 
 describe('ExpirationWatcher', () => {
@@ -20,12 +19,10 @@ describe('ExpirationWatcher', () => {
   let currentUnixTimestampSec: BigNumber;
   let timer: Sinon.SinonFakeTimers;
   let expirationWatcher: ExpirationWatcher;
-  let orderLibAddress: string;
   let marketContractAddress: string;
   let makerAccount: string;
 
   beforeAll(async () => {
-    orderLibAddress = getContractAddress('OrderLib', constants.NETWORK_ID_TRUFFLE);
     marketContractAddress = (await market.marketContractRegistry.getAddressWhiteList)[0];
     currentUnixTimestampSec = Utils.getCurrentUnixTimestampSec();
     makerAccount = web3.eth.accounts[1];
@@ -48,7 +45,6 @@ describe('ExpirationWatcher', () => {
       const orderLifetimeSec = 60;
       const expirationUnixTimestampSec = currentUnixTimestampSec.plus(orderLifetimeSec);
       const signedOrder = await market.createSignedOrderAsync(
-        orderLibAddress,
         marketContractAddress,
         expirationUnixTimestampSec,
         constants.NULL_ADDRESS,
@@ -60,7 +56,7 @@ describe('ExpirationWatcher', () => {
         new BigNumber(5000),
         Utils.generatePseudoRandomSalt()
       );
-      const orderHash = await market.createOrderHashAsync(orderLibAddress, signedOrder);
+      const orderHash = await market.createOrderHashAsync(signedOrder);
       expirationWatcher.addOrder(orderHash, signedOrder.expirationTimestamp.times(1000));
 
       const callbackAsync = (hash: string) => {
@@ -81,7 +77,6 @@ describe('ExpirationWatcher', () => {
       const orderLifetimeSec = 60;
       const expirationUnixTimestampSec = currentUnixTimestampSec.plus(orderLifetimeSec);
       const signedOrder = await market.createSignedOrderAsync(
-        orderLibAddress,
         marketContractAddress,
         expirationUnixTimestampSec,
         constants.NULL_ADDRESS,
@@ -93,7 +88,7 @@ describe('ExpirationWatcher', () => {
         new BigNumber(5000),
         Utils.generatePseudoRandomSalt()
       );
-      const orderHash = await market.createOrderHashAsync(orderLibAddress, signedOrder);
+      const orderHash = await market.createOrderHashAsync(signedOrder);
       expirationWatcher.addOrder(orderHash, signedOrder.expirationTimestamp.times(1000));
 
       const callbackAsync = (hash: string) => {
@@ -115,7 +110,6 @@ describe('ExpirationWatcher', () => {
       const order2ExpirationUnixTimestampSec = currentUnixTimestampSec.plus(order2Lifetime);
 
       const signedOrder1 = await market.createSignedOrderAsync(
-        orderLibAddress,
         marketContractAddress,
         order1ExpirationUnixTimestampSec,
         constants.NULL_ADDRESS,
@@ -129,7 +123,6 @@ describe('ExpirationWatcher', () => {
       );
 
       const signedOrder2 = await market.createSignedOrderAsync(
-        orderLibAddress,
         marketContractAddress,
         order2ExpirationUnixTimestampSec,
         constants.NULL_ADDRESS,
@@ -142,8 +135,8 @@ describe('ExpirationWatcher', () => {
         Utils.generatePseudoRandomSalt()
       );
 
-      const orderHash1 = await market.createOrderHashAsync(orderLibAddress, signedOrder1);
-      const orderHash2 = await market.createOrderHashAsync(orderLibAddress, signedOrder2);
+      const orderHash1 = await market.createOrderHashAsync(signedOrder1);
+      const orderHash2 = await market.createOrderHashAsync(signedOrder2);
 
       expirationWatcher.addOrder(orderHash2, signedOrder2.expirationTimestamp.times(1000));
       expirationWatcher.addOrder(orderHash1, signedOrder1.expirationTimestamp.times(1000));

--- a/test/OrderFilledCancelledStore.test.ts
+++ b/test/OrderFilledCancelledStore.test.ts
@@ -6,10 +6,7 @@ import { ERC20, MarketCollateralPool, MarketContract, SignedOrder } from '@marke
 import { Market, Utils } from '../src';
 import { constants } from '../src/constants';
 
-import { createOrderHashAsync, createSignedOrderAsync } from '../src/lib/Order';
-
 import { OrderFilledCancelledLazyStore } from '../src/OrderFilledCancelledLazyStore';
-import { JSONRPCResponsePayload } from '@0xproject/types';
 import { MARKETProtocolConfig } from '../src/types';
 import { createEVMSnapshot, restoreEVMSnapshot } from './utils';
 
@@ -17,7 +14,6 @@ describe('Order filled/cancelled store', async () => {
   let web3: Web3;
   let config: MARKETProtocolConfig;
   let market: Market;
-  let orderLibAddress: string;
   let contractAddresses: string[];
   let contractAddress: string;
   let deploymentAddress: string;
@@ -40,7 +36,6 @@ describe('Order filled/cancelled store', async () => {
     web3 = new Web3(new Web3.providers.HttpProvider('http://localhost:9545'));
     config = { networkId: constants.NETWORK_ID_TRUFFLE };
     market = new Market(web3.currentProvider, config);
-    orderLibAddress = market.orderLib.address;
     contractAddresses = await market.marketContractRegistry.getAddressWhiteList;
     contractAddress = contractAddresses[0];
     deploymentAddress = web3.eth.accounts[0];
@@ -64,7 +59,6 @@ describe('Order filled/cancelled store', async () => {
       from: taker
     });
     signedOrder = await market.createSignedOrderAsync(
-      orderLibAddress,
       contractAddress,
       new BigNumber(Math.floor(Date.now() / 1000) + 60 * 60),
       constants.NULL_ADDRESS,
@@ -106,11 +100,7 @@ describe('Order filled/cancelled store', async () => {
       gas: 400000
     });
 
-    const orderHash = await createOrderHashAsync(
-      web3.currentProvider,
-      orderLibAddress,
-      signedOrder
-    );
+    const orderHash = await market.createOrderHashAsync(signedOrder);
     const store = new OrderFilledCancelledLazyStore(market.marketContractWrapper);
 
     const qty = await store.getQtyFilledOrCancelledAsync(deployedMarketContract.address, orderHash);
@@ -125,11 +115,7 @@ describe('Order filled/cancelled store', async () => {
       gas: 400000
     });
 
-    const orderHash = await createOrderHashAsync(
-      web3.currentProvider,
-      orderLibAddress,
-      signedOrder
-    );
+    const orderHash = await market.createOrderHashAsync(signedOrder);
     const store = new OrderFilledCancelledLazyStore(market.marketContractWrapper);
 
     await store.getQtyFilledOrCancelledAsync(deployedMarketContract.address, orderHash);

--- a/test/OrderValidation.test.ts
+++ b/test/OrderValidation.test.ts
@@ -7,15 +7,12 @@ import { MarketError, MARKETProtocolConfig } from '../src/types';
 import { Market, Utils } from '../src';
 import { constants } from '../src/constants';
 
-import { createSignedOrderAsync } from '../src/lib/Order';
-
-import { createEVMSnapshot, getContractAddress, restoreEVMSnapshot } from './utils';
+import { createEVMSnapshot, restoreEVMSnapshot } from './utils';
 
 describe('Order Validation', async () => {
   let web3: Web3;
   let config: MARKETProtocolConfig;
   let market: Market;
-  let orderLibAddress: string;
   let contractAddresses: string[];
   let contractAddress: string;
   let deploymentAddress: string;
@@ -37,7 +34,6 @@ describe('Order Validation', async () => {
     web3 = new Web3(new Web3.providers.HttpProvider('http://localhost:9545'));
     config = { networkId: constants.NETWORK_ID_TRUFFLE };
     market = new Market(web3.currentProvider, config);
-    orderLibAddress = getContractAddress('OrderLib', constants.NETWORK_ID_TRUFFLE);
     contractAddresses = await market.marketContractRegistry.getAddressWhiteList;
     contractAddress = contractAddresses[0];
     deploymentAddress = web3.eth.accounts[0];
@@ -82,9 +78,7 @@ describe('Order Validation', async () => {
     // transfer enough MKT to maker for fees
     await market.mktTokenContract.transferTx(maker, fees).send({ from: deploymentAddress });
 
-    const signedOrder = await createSignedOrderAsync(
-      web3.currentProvider,
-      orderLibAddress,
+    const signedOrder = await market.createSignedOrderAsync(
       contractAddress,
       new BigNumber(Math.floor(Date.now() / 1000) + 60 * 60),
       feeRecipient,
@@ -116,9 +110,7 @@ describe('Order Validation', async () => {
     // maker approves token for fees
     await market.mktTokenContract.approveTx(feeRecipient, fees).send({ from: maker });
 
-    const signedOrder = await createSignedOrderAsync(
-      web3.currentProvider,
-      orderLibAddress,
+    const signedOrder = await market.createSignedOrderAsync(
       contractAddress,
       new BigNumber(Math.floor(Date.now() / 1000) + 60 * 60),
       feeRecipient,
@@ -145,9 +137,7 @@ describe('Order Validation', async () => {
       from: maker
     });
     fees = new BigNumber(0);
-    const signedOrder: SignedOrder = await createSignedOrderAsync(
-      web3.currentProvider,
-      orderLibAddress,
+    const signedOrder: SignedOrder = await market.createSignedOrderAsync(
       contractAddress,
       new BigNumber(Math.floor(Date.now() / 1000) + 60 * 60),
       constants.NULL_ADDRESS,
@@ -173,9 +163,7 @@ describe('Order Validation', async () => {
 
   it('Checks sufficient MKT balances for fees', async () => {
     fees = new BigNumber(100);
-    const signedOrder: SignedOrder = await createSignedOrderAsync(
-      web3.currentProvider,
-      orderLibAddress,
+    const signedOrder: SignedOrder = await market.createSignedOrderAsync(
       contractAddress,
       new BigNumber(Math.floor(Date.now() / 1000) + 60 * 60),
       constants.NULL_ADDRESS,
@@ -201,9 +189,7 @@ describe('Order Validation', async () => {
 
   it('Checks valid signature', async () => {
     fees = new BigNumber(0);
-    const signedOrder: SignedOrder = await createSignedOrderAsync(
-      web3.currentProvider,
-      orderLibAddress,
+    const signedOrder: SignedOrder = await market.createSignedOrderAsync(
       contractAddress,
       new BigNumber(Math.floor(Date.now() / 1000) + 60 * 60),
       constants.NULL_ADDRESS,
@@ -235,9 +221,7 @@ describe('Order Validation', async () => {
     await market.depositCollateralAsync(contractAddress, initialCredit, {
       from: taker
     });
-    const signedOrder: SignedOrder = await createSignedOrderAsync(
-      web3.currentProvider,
-      orderLibAddress,
+    const signedOrder: SignedOrder = await market.createSignedOrderAsync(
       contractAddress,
       new BigNumber(Math.floor(Date.now() / 1000) + 60 * 60),
       constants.NULL_ADDRESS,
@@ -263,9 +247,7 @@ describe('Order Validation', async () => {
 
   it('Checks valid timestamp', async () => {
     fees = new BigNumber(0);
-    const signedOrder: SignedOrder = await createSignedOrderAsync(
-      web3.currentProvider,
-      orderLibAddress,
+    const signedOrder: SignedOrder = await market.createSignedOrderAsync(
       contractAddress,
       new BigNumber(1),
       constants.NULL_ADDRESS,
@@ -291,9 +273,7 @@ describe('Order Validation', async () => {
 
   it('Checks the order is not fully filled or fully cancelled', async () => {
     fees = new BigNumber(0);
-    const signedOrder: SignedOrder = await createSignedOrderAsync(
-      web3.currentProvider,
-      orderLibAddress,
+    const signedOrder: SignedOrder = await market.createSignedOrderAsync(
       contractAddress,
       new BigNumber(Math.floor(Date.now() / 1000) + 60 * 60),
       constants.NULL_ADDRESS,
@@ -319,9 +299,7 @@ describe('Order Validation', async () => {
 
   it('Checks the order qty and the fill qty are the same sign', async () => {
     fees = new BigNumber(0);
-    const signedOrder: SignedOrder = await createSignedOrderAsync(
-      web3.currentProvider,
-      orderLibAddress,
+    const signedOrder: SignedOrder = await market.createSignedOrderAsync(
       contractAddress,
       new BigNumber(Math.floor(Date.now() / 1000) + 60 * 60),
       constants.NULL_ADDRESS,

--- a/test/RemainingFillableCalc.test.ts
+++ b/test/RemainingFillableCalc.test.ts
@@ -7,16 +7,13 @@ import { MarketError, MARKETProtocolConfig } from '../src/types';
 import { Market, Utils } from '../src';
 import { constants } from '../src/constants';
 
-import { createOrderHashAsync, createSignedOrderAsync } from '../src/lib/Order';
-
-import { createEVMSnapshot, getContractAddress, restoreEVMSnapshot } from './utils';
+import { createEVMSnapshot, restoreEVMSnapshot } from './utils';
 import { RemainingFillableCalculator } from '../src/order_watcher/RemainingFillableCalc';
 
 describe('Remaining Fillable Calculator', async () => {
   let web3: Web3;
   let config: MARKETProtocolConfig;
   let market: Market;
-  let orderLibAddress: string;
   let contractAddresses: string[];
   let contractAddress: string;
   let deploymentAddress: string;
@@ -36,7 +33,6 @@ describe('Remaining Fillable Calculator', async () => {
     web3 = new Web3(new Web3.providers.HttpProvider(constants.PROVIDER_URL_TRUFFLE));
     config = { networkId: constants.NETWORK_ID_TRUFFLE };
     market = new Market(web3.currentProvider, config);
-    orderLibAddress = getContractAddress('OrderLib', constants.NETWORK_ID_TRUFFLE);
     contractAddresses = await market.marketContractRegistry.getAddressWhiteList;
     contractAddress = contractAddresses[0];
     deploymentAddress = web3.eth.accounts[0];
@@ -82,9 +78,7 @@ describe('Remaining Fillable Calculator', async () => {
     let makerFillable: BigNumber;
     let takerFillable: BigNumber;
 
-    const signedOrder: SignedOrder = await createSignedOrderAsync(
-      web3.currentProvider,
-      orderLibAddress,
+    const signedOrder: SignedOrder = await market.createSignedOrderAsync(
       contractAddress,
       new BigNumber(Math.floor(Date.now() / 1000) + 60 * 60),
       constants.NULL_ADDRESS,
@@ -97,11 +91,7 @@ describe('Remaining Fillable Calculator', async () => {
       Utils.generatePseudoRandomSalt()
     );
 
-    const orderHash = await createOrderHashAsync(
-      web3.currentProvider,
-      orderLibAddress,
-      signedOrder
-    );
+    const orderHash = await market.createOrderHashAsync(signedOrder);
 
     const calc = new RemainingFillableCalculator(
       market,
@@ -194,9 +184,7 @@ describe('Remaining Fillable Calculator', async () => {
     const makerFee = new BigNumber(1e32);
     const takerFee = new BigNumber(0);
 
-    const signedOrder: SignedOrder = await createSignedOrderAsync(
-      web3.currentProvider,
-      orderLibAddress,
+    const signedOrder: SignedOrder = await market.createSignedOrderAsync(
       contractAddress,
       new BigNumber(Math.floor(Date.now() / 1000) + 60 * 60),
       deploymentAddress,
@@ -209,11 +197,7 @@ describe('Remaining Fillable Calculator', async () => {
       Utils.generatePseudoRandomSalt()
     );
 
-    const orderHash = await createOrderHashAsync(
-      web3.currentProvider,
-      orderLibAddress,
-      signedOrder
-    );
+    const orderHash = await market.createOrderHashAsync(signedOrder);
 
     const calc = new RemainingFillableCalculator(
       market,
@@ -249,9 +233,7 @@ describe('Remaining Fillable Calculator', async () => {
     const makerFee = new BigNumber(0);
     const takerFee = new BigNumber(1e32);
 
-    const signedOrder: SignedOrder = await createSignedOrderAsync(
-      web3.currentProvider,
-      orderLibAddress,
+    const signedOrder: SignedOrder = await market.createSignedOrderAsync(
       contractAddress,
       new BigNumber(Math.floor(Date.now() / 1000) + 60 * 60),
       deploymentAddress,
@@ -264,11 +246,7 @@ describe('Remaining Fillable Calculator', async () => {
       Utils.generatePseudoRandomSalt()
     );
 
-    const orderHash = await createOrderHashAsync(
-      web3.currentProvider,
-      orderLibAddress,
-      signedOrder
-    );
+    const orderHash = await market.createOrderHashAsync(signedOrder);
 
     const calc = new RemainingFillableCalculator(
       market,
@@ -306,9 +284,7 @@ describe('Remaining Fillable Calculator', async () => {
     let makerFillable: BigNumber;
     let takerFillable: BigNumber;
 
-    const signedOrder: SignedOrder = await createSignedOrderAsync(
-      web3.currentProvider,
-      orderLibAddress,
+    const signedOrder: SignedOrder = await market.createSignedOrderAsync(
       contractAddress,
       new BigNumber(Math.floor(Date.now() / 1000) + 60 * 60),
       constants.NULL_ADDRESS,
@@ -321,11 +297,7 @@ describe('Remaining Fillable Calculator', async () => {
       Utils.generatePseudoRandomSalt()
     );
 
-    const orderHash = await createOrderHashAsync(
-      web3.currentProvider,
-      orderLibAddress,
-      signedOrder
-    );
+    const orderHash = await market.createOrderHashAsync(signedOrder);
 
     const calc = new RemainingFillableCalculator(
       market,


### PR DESCRIPTION
##### Description
Cleans up any call where users needed to supply orderLibAddress and simplifies many other code paths / calls

##### Checklist

- [x] Linter status: 100% pass
- [x] Changes don't break existing behavior
- [x] Tests coverage hasn't decreased

##### Affected core subsystem(s)
All

##### Testing
Passing locally.


