### PR TITLE
Feature: Expose getBalanceAsync in MarketJS

### DIFF
--- a/src/Market.ts
+++ b/src/Market.ts
@@ -393,7 +393,7 @@ export class Market {
     fromBlock: number | string = '0x0',
     toBlock: number | string = 'latest',
     userAddress: string | null = null,
-    side: 'maker' | 'taker' | 'any' = 'any',
+    side: 'maker' | 'taker' | 'any' = 'any'
   ): Promise<OrderFilledEvent[]> {
     return this.marketContractWrapper.getContractFillsAsync(
       marketContractAddress,
@@ -403,6 +403,18 @@ export class Market {
       side
     );
   }
+
+  /**
+   * Retrieves an owner's ERC20 token balance.
+   *
+   * @param {string} tokenAddress The hex encoded contract Ethereum address where the ERC20 token is deployed.
+   * @param {string} ownerAddress The hex encoded user Ethereum address whose balance you would like to check.
+   * @returns {Promise<BigNumber>} The owner's ERC20 token balance in base units.
+   */
+  public async getBalanceAsync(tokenAddress: string, ownerAddress: string): Promise<BigNumber> {
+    return this.marketContractWrapper.getBalanceAsync(tokenAddress, ownerAddress);
+  }
+
   // DEPLOYMENT METHODS
 
   /**

--- a/test/Market.integrationTest.ts
+++ b/test/Market.integrationTest.ts
@@ -83,7 +83,7 @@ describe('Market class', () => {
     expect(result).toBeString();
   });
 
-  it('Returns a contract name', async () => {
+  it('Returns contract price decimal places name', async () => {
     const result: BigNumber = await market.getMarketContractPriceDecimalPlacesAsync(
       contractAddress
     );

--- a/test/Market.integrationTest.ts
+++ b/test/Market.integrationTest.ts
@@ -31,10 +31,12 @@ describe('Market class', () => {
 
   let market;
   let contractAddress: string;
+  let mktTokenAddress: string;
 
   beforeAll(async () => {
     market = new Market(web3.currentProvider, config);
     const contractAddresses: string[] = await market.marketContractRegistry.getAddressWhiteList;
+    mktTokenAddress = market.mktTokenContract.address;
     contractAddress = contractAddresses[0];
   });
 
@@ -87,5 +89,13 @@ describe('Market class', () => {
     );
     expect(result).toBeDefined();
     expect(result.toNumber()).toBeNumber();
+  });
+
+  it('Returns a tokens balance', async () => {
+    const result: BigNumber = await market.getBalanceAsync(mktTokenAddress, web3.eth.accounts[0]);
+
+    expect(result).toBeDefined();
+    expect(result.toNumber()).toBeNumber();
+    expect(result.toNumber()).not.toEqual(0);
   });
 });

--- a/test/Market.test.ts
+++ b/test/Market.test.ts
@@ -82,7 +82,7 @@ describe('Market class', () => {
     expect(result).toBeString();
   });
 
-  it('Returns a contract name', async () => {
+  it('Returns contract price decimal places name', async () => {
     const result: BigNumber = await market.getMarketContractPriceDecimalPlacesAsync(
       contractAddress
     );

--- a/test/Market.test.ts
+++ b/test/Market.test.ts
@@ -30,10 +30,12 @@ describe('Market class', () => {
 
   let market: Market;
   let contractAddress: string;
+  let mktTokenAddress: string;
 
   beforeAll(async () => {
     market = new Market(web3.currentProvider, config);
     const contractAddresses: string[] = await market.marketContractRegistry.getAddressWhiteList;
+    mktTokenAddress = market.mktTokenContract.address;
     contractAddress = contractAddresses[0];
   });
 
@@ -86,5 +88,13 @@ describe('Market class', () => {
     );
     expect(result).toBeDefined();
     expect(result.toNumber()).toBeNumber();
+  });
+
+  it('Returns a tokens balance', async () => {
+    const result: BigNumber = await market.getBalanceAsync(mktTokenAddress, web3.eth.accounts[0]);
+
+    expect(result).toBeDefined();
+    expect(result.toNumber()).toBeNumber();
+    expect(result.toNumber()).not.toEqual(0);
   });
 });


### PR DESCRIPTION
##### Description

Exposes `getBalanceAsync()` in Market,

##### Checklist

- [x] Linter status: 100% pass
- [x] Changes don't break existing behavior
- [x] Tests coverage hasn't decreased

##### Affected core subsystem(s)
MarketJS library

##### Testing

Yup! Updated the `Market.ts` test and integration test

##### Refers/Fixes

Fixes #128 