### PR TITLE
Rename getUserBalanceAsync() to getUserUnallocatedCollateralBalanceAs…

### DIFF
--- a/src/BalanceAndAllowanceLazyStore.ts
+++ b/src/BalanceAndAllowanceLazyStore.ts
@@ -199,7 +199,7 @@ export class BalanceAndAllowanceLazyStore {
       _.isUndefined(this._collateralBalance[contractAddress]) ||
       _.isUndefined(this._collateralBalance[contractAddress][userAddress])
     ) {
-      const balance = await this._contractWrapper.getUserAccountBalanceAsync(
+      const balance = await this._contractWrapper.getUserUnallocatedCollateralBalanceAsync(
         contractAddress,
         userAddress
       );

--- a/src/Market.ts
+++ b/src/Market.ts
@@ -163,16 +163,19 @@ export class Market {
   }
 
   /**
-   * Gets the user's currently unallocated token balance
+   * Gets the user's currently unallocated collateral token balance.
+   * The unallocated token balance is the balance that is already deposited into the
+   * collateral pool but has not yet be allocated for a particular trade for the marketContract.
+   *
    * @param {string} marketContractAddress            Address of the MarketContract
    * @param {BigNumber | string} userAddress          Address of user
    * @returns {Promise<BigNumber|null>}               The user's currently unallocated token balance
    */
-  public async getUserAccountBalanceAsync(
+  public async getUserUnallocatedCollateralBalanceAsync(
     marketContractAddress: string,
     userAddress: string
   ): Promise<BigNumber> {
-    return this.marketContractWrapper.getUserAccountBalanceAsync(
+    return this.marketContractWrapper.getUserUnallocatedCollateralBalanceAsync(
       marketContractAddress,
       userAddress
     );

--- a/src/contract_wrappers/ContractWrapper.ts
+++ b/src/contract_wrappers/ContractWrapper.ts
@@ -204,10 +204,10 @@ export class ContractWrapper {
     }
 
     const makerCollateralBalance: BigNumber = new BigNumber(
-      await this.getUserAccountBalanceAsync(signedOrder.contractAddress, maker)
+      await this.getUserUnallocatedCollateralBalanceAsync(signedOrder.contractAddress, maker)
     );
     const takerCollateralBalance: BigNumber = new BigNumber(
-      await this.getUserAccountBalanceAsync(signedOrder.contractAddress, taker)
+      await this.getUserUnallocatedCollateralBalanceAsync(signedOrder.contractAddress, taker)
     );
 
     const neededCollateralMaker: BigNumber = await this.calculateNeededCollateralAsync(
@@ -465,7 +465,7 @@ export class ContractWrapper {
    * @param {BigNumber | string} userAddress     address of user
    * @returns {Promise<BigNumber>}               the user's currently unallocated token balance
    */
-  public async getUserAccountBalanceAsync(
+  public async getUserUnallocatedCollateralBalanceAsync(
     marketContractAddress: string,
     userAddress: string
   ): Promise<BigNumber> {

--- a/src/order_watcher/RemainingFillableCalc.ts
+++ b/src/order_watcher/RemainingFillableCalc.ts
@@ -154,7 +154,7 @@ export class RemainingFillableCalculator {
   }
 
   private async _getAvailableCollateral(accountAddress: string): Promise<BigNumber> {
-    const balance = await this._market.getUserAccountBalanceAsync(
+    const balance = await this._market.getUserUnallocatedCollateralBalanceAsync(
       this._signedOrder.contractAddress,
       accountAddress
     );

--- a/test/BalanceAndAllowanceLazyStore.test.ts
+++ b/test/BalanceAndAllowanceLazyStore.test.ts
@@ -34,7 +34,7 @@ describe('Token Balance and Allowance store', async () => {
     ],
     [
       'getCollateralBalanceAsync',
-      'getUserAccountBalanceAsync',
+      'getUserUnallocatedCollateralBalanceAsync',
       'deleteCollateralBalance',
       new BigNumber(5),
       [token, user]

--- a/test/Collateral.test.ts
+++ b/test/Collateral.test.ts
@@ -102,15 +102,15 @@ describe('Collateral', () => {
     expect(newBalance.minus(oldBalance)).toEqual(depositAmount);
   });
 
-  it('getUserAccountBalanceAsync returns correct user balance', async () => {
-    const oldUserBalance: BigNumber = await market.getUserAccountBalanceAsync(
+  it('getUserUnallocatedCollateralBalanceAsync returns correct user balance', async () => {
+    const oldUserBalance: BigNumber = await market.getUserUnallocatedCollateralBalanceAsync(
       marketContractAddress,
       maker
     );
 
     const depositAmount: BigNumber = new BigNumber(100);
     await market.depositCollateralAsync(marketContractAddress, depositAmount, { from: maker });
-    const newUserBalance: BigNumber = await market.getUserAccountBalanceAsync(
+    const newUserBalance: BigNumber = await market.getUserUnallocatedCollateralBalanceAsync(
       marketContractAddress,
       maker
     );

--- a/test/OrderFilledCancelledStore.test.ts
+++ b/test/OrderFilledCancelledStore.test.ts
@@ -52,8 +52,14 @@ describe('Order filled/cancelled store', async () => {
     orderQty = new BigNumber(100);
     price = new BigNumber(100000);
     fees = new BigNumber(0);
-    let makerCollateral = await market.getUserAccountBalanceAsync(contractAddress, maker);
-    let takerCollateral = await market.getUserAccountBalanceAsync(contractAddress, taker);
+    let makerCollateral = await market.getUserUnallocatedCollateralBalanceAsync(
+      contractAddress,
+      maker
+    );
+    let takerCollateral = await market.getUserUnallocatedCollateralBalanceAsync(
+      contractAddress,
+      taker
+    );
     await market.withdrawCollateralAsync(contractAddress, makerCollateral, {
       from: maker
     });

--- a/test/OrderStateWatcher.test.ts
+++ b/test/OrderStateWatcher.test.ts
@@ -125,7 +125,7 @@ describe('OrderStateWatcher', () => {
         orderStateWatcher.subscribe(callback);
 
         // withdraw collateral
-        const initialBalance = await helper.market.getUserAccountBalanceAsync(
+        const initialBalance = await helper.market.getUserUnallocatedCollateralBalanceAsync(
           signedOrder.contractAddress,
           signedOrder.maker
         );

--- a/test/OrderValidation.test.ts
+++ b/test/OrderValidation.test.ts
@@ -47,8 +47,14 @@ describe('Order Validation', async () => {
     initialCredit = new BigNumber(1e23);
     orderQty = new BigNumber(100);
     price = new BigNumber(100000);
-    let makerCollateral = await market.getUserAccountBalanceAsync(contractAddress, maker);
-    let takerCollateral = await market.getUserAccountBalanceAsync(contractAddress, taker);
+    let makerCollateral = await market.getUserUnallocatedCollateralBalanceAsync(
+      contractAddress,
+      maker
+    );
+    let takerCollateral = await market.getUserUnallocatedCollateralBalanceAsync(
+      contractAddress,
+      taker
+    );
     await market.withdrawCollateralAsync(contractAddress, makerCollateral, {
       from: maker
     });


### PR DESCRIPTION
##### Description
Rename all occurences of `Market.getUserBalanceAsync()` to `getUserUnallocatedCollateralBalanceAsync()`. Also update the documentation for the method to be a little more descriptive. 

##### Checklist

- [x] Linter status: 100% pass
- [x] Changes don't break existing behaviour
- [x] Tests coverage hasn't decreased

##### Affected core subsystem(s)
Market.ts and ContractWrapper.ts

##### Refers/Fixes

Fixes #127 
