### PR TITLE
Remove all metadata getter functions

### DIFF
--- a/src/Market.ts
+++ b/src/Market.ts
@@ -342,15 +342,6 @@ export class Market {
   }
 
   /**
-   * Gets the contract expiration timestamp
-   * @param {string} marketContractAddress   MarketContract address
-   * @returns {Promise<BigNumber>}           Expiration timestamp
-   */
-  public async getContractExpirationAsync(marketContractAddress: string): Promise<BigNumber> {
-    return this.marketContractWrapper.getContractExpirationAsync(marketContractAddress);
-  }
-
-  /**
    * Gets the settlement status of the contract
    * @param {string} marketContractAddress    MarketContract address
    * @returns {Promise<boolean>}              True/false

--- a/src/Market.ts
+++ b/src/Market.ts
@@ -342,15 +342,6 @@ export class Market {
   }
 
   /**
-   * Gets the settlement status of the contract
-   * @param {string} marketContractAddress    MarketContract address
-   * @returns {Promise<boolean>}              True/false
-   */
-  public async isContractSettledAsync(marketContractAddress: string): Promise<boolean> {
-    return this.marketContractWrapper.isContractSettledAsync(marketContractAddress);
-  }
-
-  /**
    * Get the history of contract fills for maker,taker or both sides of the trade.
    * @param {string} marketContractAddress       address of the MarketContract
    * @param {string} fromBlock                   from block #

--- a/src/Market.ts
+++ b/src/Market.ts
@@ -320,15 +320,6 @@ export class Market {
   }
 
   /**
-   * Get the oracle query for the MarketContract
-   * @param marketContractAddress   MarketContract address
-   * @returns {Promise<string>}     The oracle query
-   */
-  public async getOracleQueryAsync(marketContractAddress: string): Promise<string> {
-    return this.marketContractWrapper.getOracleQueryAsync(marketContractAddress);
-  }
-
-  /**
    * Get the history of contract fills for maker,taker or both sides of the trade.
    * @param {string} marketContractAddress       address of the MarketContract
    * @param {string} fromBlock                   from block #

--- a/src/Market.ts
+++ b/src/Market.ts
@@ -313,15 +313,6 @@ export class Market {
   }
 
   /**
-   * Gets the market contract name
-   * @param {string} marketContractAddress    Address of the Market contract
-   * @returns {Promise<string>}               The contract's name
-   */
-  public async getMarketContractNameAsync(marketContractAddress: string): Promise<string> {
-    return this.marketContractWrapper.getMarketContractNameAsync(marketContractAddress);
-  }
-
-  /**
    * Gets the market contract price decimal places
    * @param {string} marketContractAddress    Address of the Market contract
    * @returns {Promise<BigNumber>}            The contract's name

--- a/src/Market.ts
+++ b/src/Market.ts
@@ -302,19 +302,6 @@ export class Market {
   // CONTRACT METHODS
 
   /**
-   * Gets the market contract price decimal places
-   * @param {string} marketContractAddress    Address of the Market contract
-   * @returns {Promise<BigNumber>}            The contract's name
-   */
-  public async getMarketContractPriceDecimalPlacesAsync(
-    marketContractAddress: string
-  ): Promise<BigNumber> {
-    return this.marketContractWrapper.getMarketContractPriceDecimalPlacesAsync(
-      marketContractAddress
-    );
-  }
-
-  /**
    * Gets contract meta data for the supplied market contract address.
    * @param marketContractAddress
    */

--- a/src/Market.ts
+++ b/src/Market.ts
@@ -302,17 +302,6 @@ export class Market {
   // CONTRACT METHODS
 
   /**
-   * Gets the collateral pool contract address
-   * @param {string} marketContractAddress    Address of the Market contract
-   * @returns {Promise<string>}               The contract's collateral pool address
-   */
-  public async getCollateralPoolContractAddressAsync(
-    marketContractAddress: string
-  ): Promise<string> {
-    return this.marketContractWrapper.getCollateralPoolContractAddressAsync(marketContractAddress);
-  }
-
-  /**
    * Gets the market contract price decimal places
    * @param {string} marketContractAddress    Address of the Market contract
    * @returns {Promise<BigNumber>}            The contract's name

--- a/src/contract_wrappers/ContractWrapper.ts
+++ b/src/contract_wrappers/ContractWrapper.ts
@@ -272,18 +272,6 @@ export class ContractWrapper {
   }
 
   /**
-   * Gets the collateral pool contract address
-   * @param {string} marketContractAddress    Address of the Market contract.
-   * @returns {Promise<string>}               The contract's name
-   */
-  public async getMarketContractNameAsync(marketContractAddress: string): Promise<string> {
-    const contractSetWrapper: ContractSet = await this._getContractSetByMarketContractAddressAsync(
-      marketContractAddress
-    );
-    return contractSetWrapper.marketContract.CONTRACT_NAME;
-  }
-
-  /**
    * Gets the market contract price decimal places
    * @param {string} marketContractAddress    Address of the Market contract
    * @returns {Promise<BigNumber>}            The contract's price decimal places

--- a/src/contract_wrappers/ContractWrapper.ts
+++ b/src/contract_wrappers/ContractWrapper.ts
@@ -272,20 +272,6 @@ export class ContractWrapper {
   }
 
   /**
-   * Gets the market contract price decimal places
-   * @param {string} marketContractAddress    Address of the Market contract
-   * @returns {Promise<BigNumber>}            The contract's price decimal places
-   */
-  public async getMarketContractPriceDecimalPlacesAsync(
-    marketContractAddress: string
-  ): Promise<BigNumber> {
-    const contractSetWrapper: ContractSet = await this._getContractSetByMarketContractAddressAsync(
-      marketContractAddress
-    );
-    return contractSetWrapper.marketContract.PRICE_DECIMAL_PLACES;
-  }
-
-  /**
    * Gets the history of contract fills for maker/taker/or both.
    * @param {string} marketContractAddress       address of the MarketContract
    * @param {string} fromBlock                   from block #

--- a/src/contract_wrappers/OraclizeContractWrapper.ts
+++ b/src/contract_wrappers/OraclizeContractWrapper.ts
@@ -49,17 +49,6 @@ export class OraclizeContractWrapper extends ContractWrapper {
   // *****************************************************************
   // ****                     Public Methods                      ****
   // *****************************************************************
-  /**
-   * Gets the MarketContract oracle query.
-   * @param {string} marketContractAddress   Address of the contract
-   * @returns {Promise<string>}                      The oracle query
-   */
-  public async getOracleQueryAsync(marketContractAddress: string): Promise<string> {
-    const contractSetWrapper: OraclizeContractSet = await this._getContractSetByMarketContractAddressAsync(
-      marketContractAddress
-    );
-    return contractSetWrapper.marketContractOraclize.ORACLE_QUERY;
-  }
 
   /**
    * Gets contract meta data for the supplied market contract address.

--- a/src/contract_wrappers/OraclizeContractWrapper.ts
+++ b/src/contract_wrappers/OraclizeContractWrapper.ts
@@ -62,18 +62,6 @@ export class OraclizeContractWrapper extends ContractWrapper {
   }
 
   /**
-   * Gets the MarketContract expiration.
-   * @param {string} marketContractAddress   Address of the contract
-   * @returns {Promise<boolean>}                     Is this contract settled?
-   */
-  public async isContractSettledAsync(marketContractAddress: string): Promise<boolean> {
-    const contractSetWrapper: OraclizeContractSet = await this._getContractSetByMarketContractAddressAsync(
-      marketContractAddress
-    );
-    return contractSetWrapper.marketContractOraclize.isSettled;
-  }
-
-  /**
    * Gets contract meta data for the supplied market contract address.
    * @param marketContractAddress
    * @returns {Promise<OraclizeContractMetaData>}

--- a/src/contract_wrappers/OraclizeContractWrapper.ts
+++ b/src/contract_wrappers/OraclizeContractWrapper.ts
@@ -64,18 +64,6 @@ export class OraclizeContractWrapper extends ContractWrapper {
   /**
    * Gets the MarketContract expiration.
    * @param {string} marketContractAddress   Address of the contract
-   * @returns {Promise<BigNumber>}                   Expiration timestamp
-   */
-  public async getContractExpirationAsync(marketContractAddress: string): Promise<BigNumber> {
-    const contractSetWrapper: OraclizeContractSet = await this._getContractSetByMarketContractAddressAsync(
-      marketContractAddress
-    );
-    return contractSetWrapper.marketContractOraclize.EXPIRATION;
-  }
-
-  /**
-   * Gets the MarketContract expiration.
-   * @param {string} marketContractAddress   Address of the contract
    * @returns {Promise<boolean>}                     Is this contract settled?
    */
   public async isContractSettledAsync(marketContractAddress: string): Promise<boolean> {

--- a/test/Market.integrationTest.ts
+++ b/test/Market.integrationTest.ts
@@ -78,7 +78,7 @@ describe('Market class', () => {
   });
 
   it('Returns a contract name', async () => {
-    const result = await market.getMarketContractNameAsync(contractAddress);
+    const result = (await market.getContractMetaDataAsync(contractAddress)).contractName;
     expect(result).toBeDefined();
     expect(result).toBeString();
   });

--- a/test/Market.integrationTest.ts
+++ b/test/Market.integrationTest.ts
@@ -66,7 +66,7 @@ describe('Market class', () => {
   });
 
   it('Returns a contract expiration', async () => {
-    const result = await market.getContractExpirationAsync(contractAddress);
+    const result = (await market.getContractMetaDataAsync(contractAddress)).expirationTimeStamp;
     expect(result).toBeDefined();
     expect(result.toNumber()).toBeNumber();
   });

--- a/test/Market.integrationTest.ts
+++ b/test/Market.integrationTest.ts
@@ -53,41 +53,43 @@ describe('Market class', () => {
     });
   });
 
-  it('Returns a collateral pool contract address', async () => {
-    const result = (await market.getContractMetaDataAsync(contractAddress)).collateralPoolAddress;
-    isValidAddress(result);
-  });
+  describe('getContractMetaDataAsync', () => {
+    it('Returns a collateral pool contract address', async () => {
+      const result = (await market.getContractMetaDataAsync(contractAddress)).collateralPoolAddress;
+      isValidAddress(result);
+    });
 
-  it('Returns a oracle query URL', async () => {
-    const result = (await market.getContractMetaDataAsync(contractAddress)).oracleQuery;
-    expect(result).toBeDefined();
-    expect(result).toBeString();
-    expect(isUrl(result.replace(/^.*\((.*)\)/, '$1'))).toBe(true);
-  });
+    it('Returns a oracle query URL', async () => {
+      const result = (await market.getContractMetaDataAsync(contractAddress)).oracleQuery;
+      expect(result).toBeDefined();
+      expect(result).toBeString();
+      expect(isUrl(result.replace(/^.*\((.*)\)/, '$1'))).toBe(true);
+    });
 
-  it('Returns a contract expiration', async () => {
-    const result = (await market.getContractMetaDataAsync(contractAddress)).expirationTimeStamp;
-    expect(result).toBeDefined();
-    expect(result.toNumber()).toBeNumber();
-  });
+    it('Returns a contract expiration', async () => {
+      const result = (await market.getContractMetaDataAsync(contractAddress)).expirationTimeStamp;
+      expect(result).toBeDefined();
+      expect(result.toNumber()).toBeNumber();
+    });
 
-  it('Returns a settlement status', async () => {
-    const result = (await market.getContractMetaDataAsync(contractAddress)).isSettled;
-    expect(result).toBeDefined();
-    expect(result).toBeBoolean();
-  });
+    it('Returns a settlement status', async () => {
+      const result = (await market.getContractMetaDataAsync(contractAddress)).isSettled;
+      expect(result).toBeDefined();
+      expect(result).toBeBoolean();
+    });
 
-  it('Returns a contract name', async () => {
-    const result = (await market.getContractMetaDataAsync(contractAddress)).contractName;
-    expect(result).toBeDefined();
-    expect(result).toBeString();
-  });
+    it('Returns a contract name', async () => {
+      const result = (await market.getContractMetaDataAsync(contractAddress)).contractName;
+      expect(result).toBeDefined();
+      expect(result).toBeString();
+    });
 
-  it('Returns contract price decimal places name', async () => {
-    const result: BigNumber = (await market.getContractMetaDataAsync(contractAddress))
-      .priceDecimalPlaces;
-    expect(result).toBeDefined();
-    expect(result.toNumber()).toBeNumber();
+    it('Returns contract price decimal places name', async () => {
+      const result: BigNumber = (await market.getContractMetaDataAsync(contractAddress))
+        .priceDecimalPlaces;
+      expect(result).toBeDefined();
+      expect(result.toNumber()).toBeNumber();
+    });
   });
 
   it('Returns a tokens balance', async () => {

--- a/test/Market.integrationTest.ts
+++ b/test/Market.integrationTest.ts
@@ -59,7 +59,7 @@ describe('Market class', () => {
   });
 
   it('Returns a oracle query URL', async () => {
-    const result = await market.getOracleQueryAsync(contractAddress);
+    const result = (await market.getContractMetaDataAsync(contractAddress)).oracleQuery;
     expect(result).toBeDefined();
     expect(result).toBeString();
     expect(isUrl(result.replace(/^.*\((.*)\)/, '$1'))).toBe(true);

--- a/test/Market.integrationTest.ts
+++ b/test/Market.integrationTest.ts
@@ -72,7 +72,7 @@ describe('Market class', () => {
   });
 
   it('Returns a settlement status', async () => {
-    const result = await market.isContractSettledAsync(contractAddress);
+    const result = (await market.getContractMetaDataAsync(contractAddress)).isSettled;
     expect(result).toBeDefined();
     expect(result).toBeBoolean();
   });

--- a/test/Market.integrationTest.ts
+++ b/test/Market.integrationTest.ts
@@ -84,9 +84,8 @@ describe('Market class', () => {
   });
 
   it('Returns contract price decimal places name', async () => {
-    const result: BigNumber = await market.getMarketContractPriceDecimalPlacesAsync(
-      contractAddress
-    );
+    const result: BigNumber = (await market.getContractMetaDataAsync(contractAddress))
+      .priceDecimalPlaces;
     expect(result).toBeDefined();
     expect(result.toNumber()).toBeNumber();
   });

--- a/test/Market.integrationTest.ts
+++ b/test/Market.integrationTest.ts
@@ -54,7 +54,7 @@ describe('Market class', () => {
   });
 
   it('Returns a collateral pool contract address', async () => {
-    const result = await market.getCollateralPoolContractAddressAsync(contractAddress);
+    const result = (await market.getContractMetaDataAsync(contractAddress)).collateralPoolAddress;
     isValidAddress(result);
   });
 

--- a/test/Market.test.ts
+++ b/test/Market.test.ts
@@ -77,7 +77,7 @@ describe('Market class', () => {
   });
 
   it('Returns a contract name', async () => {
-    const result = await market.getMarketContractNameAsync(contractAddress);
+    const result = (await market.getContractMetaDataAsync(contractAddress)).contractName;
     expect(result).toBeDefined();
     expect(result).toBeString();
   });

--- a/test/Market.test.ts
+++ b/test/Market.test.ts
@@ -58,7 +58,7 @@ describe('Market class', () => {
   });
 
   it('Returns a oracle query URL', async () => {
-    const result = await market.getOracleQueryAsync(contractAddress);
+    const result = (await market.getContractMetaDataAsync(contractAddress)).oracleQuery;
     expect(result).toBeDefined();
     expect(result).toBeString();
     expect(isUrl(result.replace(/^.*\((.*)\)/, '$1'))).toBe(true);

--- a/test/Market.test.ts
+++ b/test/Market.test.ts
@@ -52,41 +52,43 @@ describe('Market class', () => {
     });
   });
 
-  it('Returns a collateral pool contract address', async () => {
-    const result = (await market.getContractMetaDataAsync(contractAddress)).collateralPoolAddress;
-    isValidAddress(result);
-  });
+  describe('getContractMetaDataAsync', () => {
+    it('Returns a collateral pool contract address', async () => {
+      const result = (await market.getContractMetaDataAsync(contractAddress)).collateralPoolAddress;
+      isValidAddress(result);
+    });
 
-  it('Returns a oracle query URL', async () => {
-    const result = (await market.getContractMetaDataAsync(contractAddress)).oracleQuery;
-    expect(result).toBeDefined();
-    expect(result).toBeString();
-    expect(isUrl(result.replace(/^.*\((.*)\)/, '$1'))).toBe(true);
-  });
+    it('Returns a oracle query URL', async () => {
+      const result = (await market.getContractMetaDataAsync(contractAddress)).oracleQuery;
+      expect(result).toBeDefined();
+      expect(result).toBeString();
+      expect(isUrl(result.replace(/^.*\((.*)\)/, '$1'))).toBe(true);
+    });
 
-  it('Returns a contract expiration', async () => {
-    const result = (await market.getContractMetaDataAsync(contractAddress)).expirationTimeStamp;
-    expect(result).toBeDefined();
-    expect(result.toNumber()).toBeNumber();
-  });
+    it('Returns a contract expiration', async () => {
+      const result = (await market.getContractMetaDataAsync(contractAddress)).expirationTimeStamp;
+      expect(result).toBeDefined();
+      expect(result.toNumber()).toBeNumber();
+    });
 
-  it('Returns a settlement status', async () => {
-    const result = (await market.getContractMetaDataAsync(contractAddress)).isSettled;
-    expect(result).toBeDefined();
-    expect(result).toBeBoolean();
-  });
+    it('Returns a settlement status', async () => {
+      const result = (await market.getContractMetaDataAsync(contractAddress)).isSettled;
+      expect(result).toBeDefined();
+      expect(result).toBeBoolean();
+    });
 
-  it('Returns a contract name', async () => {
-    const result = (await market.getContractMetaDataAsync(contractAddress)).contractName;
-    expect(result).toBeDefined();
-    expect(result).toBeString();
-  });
+    it('Returns a contract name', async () => {
+      const result = (await market.getContractMetaDataAsync(contractAddress)).contractName;
+      expect(result).toBeDefined();
+      expect(result).toBeString();
+    });
 
-  it('Returns contract price decimal places name', async () => {
-    const result: BigNumber = (await market.getContractMetaDataAsync(contractAddress))
-      .priceDecimalPlaces;
-    expect(result).toBeDefined();
-    expect(result.toNumber()).toBeNumber();
+    it('Returns contract price decimal places name', async () => {
+      const result: BigNumber = (await market.getContractMetaDataAsync(contractAddress))
+        .priceDecimalPlaces;
+      expect(result).toBeDefined();
+      expect(result.toNumber()).toBeNumber();
+    });
   });
 
   it('Returns a tokens balance', async () => {

--- a/test/Market.test.ts
+++ b/test/Market.test.ts
@@ -71,7 +71,7 @@ describe('Market class', () => {
   });
 
   it('Returns a settlement status', async () => {
-    const result = await market.isContractSettledAsync(contractAddress);
+    const result = (await market.getContractMetaDataAsync(contractAddress)).isSettled;
     expect(result).toBeDefined();
     expect(result).toBeBoolean();
   });

--- a/test/Market.test.ts
+++ b/test/Market.test.ts
@@ -83,9 +83,8 @@ describe('Market class', () => {
   });
 
   it('Returns contract price decimal places name', async () => {
-    const result: BigNumber = await market.getMarketContractPriceDecimalPlacesAsync(
-      contractAddress
-    );
+    const result: BigNumber = (await market.getContractMetaDataAsync(contractAddress))
+      .priceDecimalPlaces;
     expect(result).toBeDefined();
     expect(result.toNumber()).toBeNumber();
   });

--- a/test/Market.test.ts
+++ b/test/Market.test.ts
@@ -53,7 +53,7 @@ describe('Market class', () => {
   });
 
   it('Returns a collateral pool contract address', async () => {
-    const result = await market.getCollateralPoolContractAddressAsync(contractAddress);
+    const result = (await market.getContractMetaDataAsync(contractAddress)).collateralPoolAddress;
     isValidAddress(result);
   });
 

--- a/test/Market.test.ts
+++ b/test/Market.test.ts
@@ -65,7 +65,7 @@ describe('Market class', () => {
   });
 
   it('Returns a contract expiration', async () => {
-    const result = await market.getContractExpirationAsync(contractAddress);
+    const result = (await market.getContractMetaDataAsync(contractAddress)).expirationTimeStamp;
     expect(result).toBeDefined();
     expect(result.toNumber()).toBeNumber();
   });


### PR DESCRIPTION
##### Description

Removes all getter functions to now being handled by the getContractMetaDataAsync function

##### Checklist

- [x] Linter status: 100% pass
- [x] Changes don't break existing behavior
- [x] Tests coverage hasn't decreased

##### Affected core subsystem(s)
Market class

##### Refers/Fixes

Fixes #129 