### PR TITLE
Bump version of @marketprotocol/abi to 0.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -98,9 +98,9 @@
       }
     },
     "@marketprotocol/abis": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@marketprotocol/abis/-/abis-0.0.1.tgz",
-      "integrity": "sha512-TJ4fKkqKhozunStAuJimSpuykPCkYAfF/Ry3f/Fh4n9lKz0tYPvCFDkn/N5drjEKsmmL0t+i/ggiqCDjsyYd4A=="
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@marketprotocol/abis/-/abis-0.0.2.tgz",
+      "integrity": "sha512-n8vBbQQYfCEhzOE1LbgznQdlYh8IILCognfymuDKhk56t7heyHah+Maf2g7VZazJsNUop13tHSNrKv5kbDIgJw=="
     },
     "@marketprotocol/marketprotocol": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "setupTestFrameworkScriptFile": "jest-extended"
   },
   "dependencies": {
-    "@marketprotocol/abis": "0.0.1",
+    "@marketprotocol/abis": "0.0.2",
     "abi-decoder": "^1.1.0",
     "bignumber.js": "^7.2.1",
     "bintrees": "^1.0.2",


### PR DESCRIPTION
##### Description
Increase version of marketprotocol abi in package.json to 0.0.2 

##### Checklist

- [x] Linter status: 100% pass
- [x] Changes don't break existing behavior
- [x] Tests coverage hasn't decreased

##### Affected core subsystem(s)
Package Dependencies

##### Refers/Fixes
Refers to #131 
