### PR TITLE
[138] Move all stores into /stores directory

### DIFF
--- a/src/order_watcher/OrderStateWatcher.ts
+++ b/src/order_watcher/OrderStateWatcher.ts
@@ -16,8 +16,11 @@ import { assert } from '../assert';
 import { ExpirationWatcher } from './ExpirationWatcher';
 import { EventWatcher } from './EventWatcher';
 import { Market, Utils } from '..';
-import { OrderFilledCancelledLazyStore } from '../OrderFilledCancelledLazyStore';
-import { BalanceAndAllowanceLazyStore } from '../BalanceAndAllowanceLazyStore';
+import {
+  BalanceAndAllowanceLazyStore,
+  OrderCollateralPoolAndTokenLazyStore,
+  OrderFilledCancelledLazyStore
+} from '../stores';
 import { IntervalUtils } from '../lib/Utils';
 import { AbiDecoder } from '../lib/AbiDecoder';
 import {
@@ -34,7 +37,6 @@ import {
   UserUpdatedLockedBalanceEventArgs
 } from '../types/ContractEvents';
 import { OrderStateUtils } from '../utilities/OrderStateUtils';
-import { OrderCollateralPoolAndTokenLazyStore } from '../OrderCollateralPoolAndTokenLazyStore';
 
 interface DependentOrderHashes {
   [makerAddress: string]: {

--- a/src/stores/BalanceAndAllowanceLazyStore.ts
+++ b/src/stores/BalanceAndAllowanceLazyStore.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from 'bignumber.js';
 import * as _ from 'lodash';
 
-import { ContractWrapper } from './contract_wrappers/ContractWrapper';
+import { ContractWrapper } from '../contract_wrappers/ContractWrapper';
 
 /**
  * Store to keep track of token balances and allowances

--- a/src/stores/OrderCollateralPoolAndTokenLazyStore.ts
+++ b/src/stores/OrderCollateralPoolAndTokenLazyStore.ts
@@ -1,6 +1,6 @@
 import * as _ from 'lodash';
 
-import { ContractWrapper } from './contract_wrappers/ContractWrapper';
+import { ContractWrapper } from '../contract_wrappers/ContractWrapper';
 
 /**
  * Cache to make fetching collateral pool and collateral token addresses

--- a/src/stores/OrderFilledCancelledLazyStore.ts
+++ b/src/stores/OrderFilledCancelledLazyStore.ts
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js';
 import * as _ from 'lodash';
-import { ContractWrapper } from './contract_wrappers/ContractWrapper';
+import { ContractWrapper } from '../contract_wrappers/ContractWrapper';
 
 interface InstanceFilledCancelledStore {
   filledOrCancelledQty: {

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,0 +1,3 @@
+export { BalanceAndAllowanceLazyStore } from './BalanceAndAllowanceLazyStore';
+export { OrderCollateralPoolAndTokenLazyStore } from './OrderCollateralPoolAndTokenLazyStore';
+export { OrderFilledCancelledLazyStore } from './OrderFilledCancelledLazyStore';

--- a/src/utilities/OrderStateUtils.ts
+++ b/src/utilities/OrderStateUtils.ts
@@ -1,7 +1,10 @@
 import BigNumber from 'bignumber.js';
 
-import { OrderFilledCancelledLazyStore } from '../OrderFilledCancelledLazyStore';
-import { BalanceAndAllowanceLazyStore } from '../BalanceAndAllowanceLazyStore';
+import {
+  BalanceAndAllowanceLazyStore,
+  OrderCollateralPoolAndTokenLazyStore,
+  OrderFilledCancelledLazyStore
+} from '../stores';
 import { SignedOrder } from '@marketprotocol/types';
 import {
   MarketError,
@@ -13,7 +16,6 @@ import {
 import { Utils } from '../lib/Utils';
 import { RemainingFillableCalculator } from '../order_watcher/RemainingFillableCalc';
 import { Market } from '..';
-import { OrderCollateralPoolAndTokenLazyStore } from '../OrderCollateralPoolAndTokenLazyStore';
 
 /**
  * Utility class for computing and returning the state of an order.

--- a/test/BalanceAndAllowanceLazyStore.test.ts
+++ b/test/BalanceAndAllowanceLazyStore.test.ts
@@ -3,7 +3,7 @@ import BigNumber from 'bignumber.js';
 
 import { Market, Utils } from '../src';
 
-import { BalanceAndAllowanceLazyStore } from '../src/BalanceAndAllowanceLazyStore';
+import { BalanceAndAllowanceLazyStore } from '../src/stores';
 import { ContractWrapper } from '../src/contract_wrappers/ContractWrapper';
 
 describe('Token Balance and Allowance store', async () => {

--- a/test/OrderCollateralPoolAndTokenLazyStore.test.ts
+++ b/test/OrderCollateralPoolAndTokenLazyStore.test.ts
@@ -3,7 +3,7 @@ import BigNumber from 'bignumber.js';
 
 import { Market } from '../src';
 
-import { OrderCollateralPoolAndTokenLazyStore } from '../src/OrderCollateralPoolAndTokenLazyStore';
+import { OrderCollateralPoolAndTokenLazyStore } from '../src/stores';
 import { ContractWrapper } from '../src/contract_wrappers/ContractWrapper';
 
 describe('Order Collateral Pool And Token store', async () => {

--- a/test/OrderFilledCancelledStore.test.ts
+++ b/test/OrderFilledCancelledStore.test.ts
@@ -6,7 +6,7 @@ import { ERC20, MarketCollateralPool, MarketContract, SignedOrder } from '@marke
 import { Market, Utils } from '../src';
 import { constants } from '../src/constants';
 
-import { OrderFilledCancelledLazyStore } from '../src/OrderFilledCancelledLazyStore';
+import { OrderFilledCancelledLazyStore } from '../src/stores';
 import { MARKETProtocolConfig } from '../src/types';
 import { createEVMSnapshot, restoreEVMSnapshot } from './utils';
 


### PR DESCRIPTION
##### Description
Moved all stores into `src/stores` directory

##### Checklist
- [x] Linter status: 100% pass
- [x] Changes don't break existing behavior
- [x] Tests coverage hasn't decreased

##### Refers/Fixes
Fixes: #138 
