### PR TITLE
Fix isSchemaValid() and add isSchemaValid assertions for signedOrder

### DIFF
--- a/src/assert.ts
+++ b/src/assert.ts
@@ -39,7 +39,7 @@ export const assert = {
     }
     const validationResult = schemaValidator.validate(value, schema);
     const hasValidationErrors = validationResult.errors.length > 0;
-    const msg = `Expected ${variableName} to confirm to schema ${schema.id}
+    const msg = `Expected ${variableName} to conform to schema ${schema.id}
       Encountered: ${JSON.stringify(value, null, '\t')}
       Validation errors: ${validationResult.errors.join(', ')}`;
     this.assert(!hasValidationErrors, msg);

--- a/src/contract_wrappers/ContractWrapper.ts
+++ b/src/contract_wrappers/ContractWrapper.ts
@@ -15,6 +15,7 @@ import {
 
 import { Transaction } from '@0xproject/types';
 import { CollateralEvent, MarketError, OrderFilledEvent } from '../types';
+import { schemas } from '../schemas';
 import { assert } from '../assert';
 
 import { Utils } from '../lib/Utils';
@@ -112,7 +113,7 @@ export class ContractWrapper {
     fillQty: BigNumber,
     txParams: ITxParams = {}
   ): Promise<OrderTransactionInfo> {
-    // assert.isSchemaValid('SignedOrder', signedOrder, schemas.SignedOrderSchema);
+    assert.isSchemaValid('signedOrder', signedOrder, schemas.SignedOrderSchema);
 
     const contractSetWrapper: ContractSet = await this._getContractSetByMarketContractAddressAsync(
       signedOrder.contractAddress

--- a/src/lib/Order.ts
+++ b/src/lib/Order.ts
@@ -7,6 +7,7 @@ import { ECSignature, Order, OrderLib, SignedOrder } from '@marketprotocol/types
 
 import { Utils } from './Utils';
 import { assert } from '../assert';
+import { schemas } from '../schemas';
 
 let ethUtil = require('ethereumjs-util');
 
@@ -21,7 +22,7 @@ export async function createOrderHashAsync(
   order: Order | SignedOrder
 ): Promise<string> {
   // below assert statement fails due to issues with BigNumber vs Number.
-  // assert.isSchemaValid('Order', order, schemas.OrderSchema);
+  assert.isSchemaValid('Order', order, schemas.OrderSchema);
 
   return orderLib
     .createOrderHash(
@@ -119,6 +120,8 @@ export async function isValidSignatureAsync(
   signedOrder: SignedOrder,
   orderHash: string
 ): Promise<boolean> {
+  assert.isSchemaValid('signedOrder', signedOrder, schemas.SignedOrderSchema);
+
   return orderLib.isValidSignature(
     signedOrder.maker,
     orderHash,

--- a/src/lib/Utils.ts
+++ b/src/lib/Utils.ts
@@ -12,6 +12,8 @@ import { Artifact, ECSignature, Order, SignedOrder } from '@marketprotocol/types
 import { constants } from '../constants';
 const fs = require('fs');
 import { ParsedContractName, SolidityTypes } from '../types';
+import { assert } from '../assert';
+import { schemas } from '../schemas';
 
 export const Utils = {
   /**
@@ -182,6 +184,8 @@ export const Utils = {
    * @return {string}
    */
   getOrderHash(order: Order | SignedOrder): string {
+    assert.isSchemaValid('order', order, schemas.OrderSchema);
+
     const orderParts = [
       { value: order.contractAddress, type: SolidityTypes.Address },
       { value: order.maker, type: SolidityTypes.Address },

--- a/src/order_watcher/OrderStateWatcher.ts
+++ b/src/order_watcher/OrderStateWatcher.ts
@@ -37,6 +37,7 @@ import {
   UserUpdatedLockedBalanceEventArgs
 } from '../types/ContractEvents';
 import { OrderStateUtils } from '../utilities/OrderStateUtils';
+import { schemas } from '../schemas';
 
 interface DependentOrderHashes {
   [makerAddress: string]: {
@@ -200,6 +201,7 @@ export class OrderStateWatcher {
    * @param {SignedOrder} signedOrder
    */
   public async addOrder(signedOrder: SignedOrder): Promise<void> {
+    assert.isSchemaValid('signedOrder', signedOrder, schemas.SignedOrderSchema);
     const orderHash = Utils.getOrderHash(signedOrder);
     assert.isValidSignature(orderHash, signedOrder.ecSignature, signedOrder.maker);
 

--- a/src/schemas/ValidationSchema.ts
+++ b/src/schemas/ValidationSchema.ts
@@ -27,6 +27,6 @@ export const ECSignatureSchema = {
 
 export const NumberSchema = {
   id: '/Number',
-  type: 'number',
-  pattern: '^\\d+(\\.\\d+)?$'
+  type: 'string',
+  pattern: '([-+]?\\d*\\.?\\d+)(?:[eE]([-+]?\\d+))?$'
 };

--- a/test/Assert.test.ts
+++ b/test/Assert.test.ts
@@ -4,6 +4,7 @@ import FakeProvider from 'web3-fake-provider';
 import Web3 from 'web3';
 
 import { assert } from '../src/assert';
+import { schemas } from '../src/schemas';
 
 describe('Assert library', () => {
   const variableName = 'variable';
@@ -164,6 +165,29 @@ describe('Assert library', () => {
       await expect(
         assert.isSenderAddressAsync(variableName, senderAddress, new Web3(mockProvider))
       ).rejects.toThrow();
+    });
+  });
+
+  describe('isSchemaValid', () => {
+    it.each([
+      ['validETHAddress', '0xc1912fee45d61c87cc5ea59dae31190fffff232d', schemas.AddressSchema],
+      ['validNumber', '1234', schemas.NumberSchema],
+      ['validFloatNumber', '123.45', schemas.NumberSchema],
+      ['validNumberWithExponent', '1.23e-5', schemas.NumberSchema],
+      ['validNumberWithSign', '-25', schemas.NumberSchema],
+      ['validNumberWithSignAndExponent', '-45.34e+20', schemas.NumberSchema]
+    ])('should not throw for %s', (name, value, schema) => {
+      const validETHAddress = '0xc1912fee45d61c87cc5ea59dae31190fffff232d';
+      expect(() => {
+        assert.isSchemaValid(name, value, schema);
+      }).not.toThrow();
+    });
+
+    it('should throw for invalid schema', () => {
+      const invalidETHAddress = '0x';
+      expect(() => {
+        assert.isSchemaValid('invalidETHAddress', invalidETHAddress, schemas.AddressSchema);
+      }).toThrow();
     });
   });
 });

--- a/test/OrderValidation.test.ts
+++ b/test/OrderValidation.test.ts
@@ -212,7 +212,7 @@ describe('Order Validation', async () => {
       Utils.generatePseudoRandomSalt(),
       false
     );
-    signedOrder.ecSignature.s = '0x';
+    signedOrder.ecSignature.s = signedOrder.ecSignature.r; // corrupt signature
 
     expect.assertions(1);
     try {


### PR DESCRIPTION
##### Description

This PR fixes the issue with isSchemaValid not recognizing numbers in schemas properly.

##### Checklist

- [x] Linter status: 100% pass
- [x] Changes don't break existing behavior
- [x] Tests coverage hasn't decreased

##### Affected core subsystem(s)
Assertions

##### Refers/Fixes

Refs: #135 