### PR TITLE
add utils getNetWorkID method and tests

### DIFF
--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -70,10 +70,6 @@ module.exports = function(deployer, network) {
           deployer.deploy(CollateralToken, 'Stable USD', 'USD', 1e9, 18);
           deployer.deploy(CollateralToken, 'Wrapped ETH', 'WETH', 1e9, 18);
 
-          const daysToExpiration = 28;
-          const expirationDate = new Date();
-          expirationDate.setDate(expirationDate.getDate() + daysToExpiration);
-
           // deploy and set up main factory to create MARKET Protocol smart contracts.
           return MarketContractRegistry.deployed().then(function(
             marketContractRegistry

--- a/src/lib/Utils.ts
+++ b/src/lib/Utils.ts
@@ -204,6 +204,24 @@ export const Utils = {
     const hashBuff = ethABI.soliditySHA3(types, values);
     const hashHex = ethUtil.bufferToHex(hashBuff);
     return hashHex;
+  },
+
+  /**
+   * Returns a promise which resolves with the ETH networkId string. The promise will be rejected
+   * if an error occurs.
+   * @method networkId
+   * @return {Promise<string>}
+   */
+  getNetworkId(web3: Web3): Promise<string> {
+    return new Promise((resolve, reject) => {
+      web3.version.getNetwork((error, networkId) => {
+        if (error) {
+          reject(`Unable to connect. Please check your PROVIDER or start truffle.`);
+        } else {
+          resolve(networkId);
+        }
+      });
+    });
   }
 };
 

--- a/test/Utils.test.ts
+++ b/test/Utils.test.ts
@@ -6,6 +6,7 @@ import FakeProvider from 'web3-fake-provider';
 // Types
 import { ECSignature } from '@marketprotocol/types';
 import { Utils } from '../src';
+import { cat } from 'shelljs';
 
 /**
  * Utils
@@ -77,5 +78,20 @@ describe('Utils library', () => {
       'PE'
     );
     expect(contractName).toEqual('BTC_USDT_BIN_123_PE');
+  });
+
+  it('returns a correct network id', async () => {
+    let web3 = new Web3(new Web3.providers.HttpProvider('http://localhost:9545'));
+    const networkID: string = await Utils.getNetworkId(web3);
+    expect(networkID).toEqual('4447');
+  });
+
+  it('fails to return a network id when not connected to valid provider', async () => {
+    let web3 = new Web3(new Web3.providers.HttpProvider('http://fake:9545'));
+    try {
+      await Utils.getNetworkId(web3);
+    } catch (e) {
+      expect(e).toBe('Unable to connect. Please check your PROVIDER or start truffle.');
+    }
   });
 });

--- a/test/Utils.test.ts
+++ b/test/Utils.test.ts
@@ -6,7 +6,6 @@ import FakeProvider from 'web3-fake-provider';
 // Types
 import { ECSignature } from '@marketprotocol/types';
 import { Utils } from '../src';
-import { cat } from 'shelljs';
 
 /**
  * Utils


### PR DESCRIPTION
##### Description
adds simple util method that was in the service listener, and I was going to use in our demo projects. 

##### Checklist
- [x] Linter status: 100% pass
- [x] Changes don't break existing behavior
- [x] Tests coverage hasn't decreased

##### Affected core subsystem(s)
utils
