### PR TITLE
remove bad call to isSenderAddress

### DIFF
--- a/src/contract_wrappers/ContractWrapper.ts
+++ b/src/contract_wrappers/ContractWrapper.ts
@@ -765,8 +765,6 @@ export class ContractWrapper {
     assert.isETHAddressHex('ownerAddress', ownerAddress);
     assert.isETHAddressHex('tokenAddress', tokenAddress);
     assert.isETHAddressHex('spenderAddress', spenderAddress);
-    await assert.isSenderAddressAsync('ownerAddress', ownerAddress, this._web3);
-
     const tokenContract = await this.getERC20TokenContractAsync(tokenAddress);
     return tokenContract.allowance(ownerAddress, spenderAddress);
   }


### PR DESCRIPTION
##### Description
removes the call to isSenderAddress that isn't needed.

##### Checklist
- [x] Linter status: 100% pass
- [x] Changes don't break existing behavior
- [x] Tests coverage hasn't decreased
